### PR TITLE
Rework HMI station to use an abstract class to include in the library

### DIFF
--- a/src/main/java/frc/alotobots/RobotContainer.java
+++ b/src/main/java/frc/alotobots/RobotContainer.java
@@ -67,9 +67,9 @@ public class RobotContainer {
         if (drivetrainSubsystem != null) {
             drivetrainSubsystem.setDefaultCommand(
                     drivetrainSubsystem.applyRequest(() -> driveFieldCentric
-                            .withVelocityX(hmiStation.driveFwdAxis() * hmiStation.getDriveXYPerfMode())
-                            .withVelocityY(hmiStation.driveStrAxis() * hmiStation.getDriveXYPerfMode())
-                            .withRotationalRate(hmiStation.driveRotAxis() * hmiStation.getDriveRotPerfMode())
+                            .withVelocityX(hmiStation.getDriveFwd() * hmiStation.getDriveXYPerfMode())
+                            .withVelocityY(hmiStation.getDriveStr() * hmiStation.getDriveXYPerfMode())
+                            .withRotationalRate(hmiStation.getDriveRot() * hmiStation.getDriveRotPerfMode())
                     )
             );
         }
@@ -86,15 +86,15 @@ public class RobotContainer {
      */
     private void configureLogicCommands() {
         if (drivetrainSubsystem != null) {
-            hmiStation.robotCentric.whileTrue(
+            hmiStation.getRobotCentricButton().whileTrue(
                     drivetrainSubsystem.applyRequest(() -> driveRobotCentric
-                            .withVelocityX(hmiStation.driveFwdAxis() * hmiStation.getDriveXYPerfMode())
-                            .withVelocityY(hmiStation.driveStrAxis() * hmiStation.getDriveXYPerfMode())
-                            .withRotationalRate(hmiStation.driveRotAxis() * hmiStation.getDriveRotPerfMode())
+                            .withVelocityX(hmiStation.getDriveFwd() * hmiStation.getDriveXYPerfMode())
+                            .withVelocityY(hmiStation.getDriveStr() * hmiStation.getDriveXYPerfMode())
+                            .withRotationalRate(hmiStation.getDriveRot() * hmiStation.getDriveRotPerfMode())
                     )
             );
 
-            hmiStation.gyroResetButton.onTrue(drivetrainSubsystem.runOnce(drivetrainSubsystem::seedFieldRelative));
+            hmiStation.getGyroResetButton().onTrue(drivetrainSubsystem.runOnce(drivetrainSubsystem::seedFieldRelative));
         }
 
         // Add other logic-based commands here

--- a/src/main/java/frc/alotobots/game/HMIStation.java
+++ b/src/main/java/frc/alotobots/game/HMIStation.java
@@ -1,205 +1,65 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
-
 package frc.alotobots.game;
 
-import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.POVButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.alotobots.Constants.Robot.Calibrations.DriveTrain;
+import frc.alotobots.library.HMIStationLib;
 import frc.alotobots.library.driverstation.JoystickUtilities;
+import lombok.Getter;
 
-/**
- * The DriverStation class represents the available inputs to the robot, providing access to controllers
- * and defining buttons for various commands.
- */
-public class HMIStation {
-  
-  final SlewRateLimiter driveXSpdFilter = new SlewRateLimiter(DriveTrain.DRIVE_TRAIN_MAX_ACCEL,DriveTrain.DRIVE_TRAIN_MAX_DECCEL,0);
-  final SlewRateLimiter driveYSpdFilter = new SlewRateLimiter(DriveTrain.DRIVE_TRAIN_MAX_ACCEL,DriveTrain.DRIVE_TRAIN_MAX_DECCEL,0);
-
-  final SlewRateLimiter driveSpdPerfModeSwFilter = new SlewRateLimiter(DriveTrain.DRIVE_XY_SPD_PERF_MODE_SW_FILTER_RATE);
-  final SlewRateLimiter driveRotPerfModeSwFilter = new SlewRateLimiter(DriveTrain.DRIVE_ROT_SPD_PERF_MODE_SW_FILTER_RATE);
-
-  // **** Driver Controller ****
+public class HMIStation extends HMIStationLib {
   private final XboxController driverController = new XboxController(0);
-
-  // Driver Buttons
-  public final JoystickButton shooterRollerIn = new JoystickButton(driverController, 1);
-  //public final JoystickButton robotCentric = new JoystickButton(driverController, 2);
-  public final JoystickButton shooterTransfer = new JoystickButton(driverController, 3);
-  public final JoystickButton gyroResetButton = new JoystickButton(driverController, 4);
-  public final JoystickButton turtleModeButton = new JoystickButton(driverController, 5);
-  public final JoystickButton turboModeButton = new JoystickButton(driverController, 6);
-
-  // Driver POV
-  public final POVButton climberUp = new POVButton(driverController, 0);
-  //public final POVButton blankDriverPOVRightButton = new POVButton(driverController, 90);
-  public final POVButton climberDn = new POVButton(driverController, 180);
-  public final POVButton shooterSlowButton = new POVButton(driverController, 270);
-
-  // Driver Axes
-  /**
-   * Gets the raw forward axis value for driving.
-   * 
-   * @return The value used for driving forward. unmodified. 
-   */
-  public double driveFwdAxisRaw() {
-    return -1*driverController.getRawAxis(1);
-    
-  }
-
-  /**
-   * Gets the Drive Forward Axis with deadband, squared and rate limited
-   * @return double Forward Axis with deadband, squared and rate limited
-   */
-  public double driveFwdAxis() {
-    return driveXSpdFilter.calculate(-1*driverController.getRawAxis(1));
-  }
-
-  /**
-   * Gets the strafe raw axis value for driving. unmodified.
-   *
-   * @return The strafe axis value.
-   */ 
-  public double driveStrAxisRaw() {
-    return -1*driverController.getRawAxis(0);
-  }
-
-  /**
-   * Gets the Drive Strafe Axis with deadband, squared and rate limited
-   * @return double Strafe Axis with deadband, squared and rate limited
-   */
-  public double driveStrAxis() {
-    return driveYSpdFilter.calculate(-1*driverController.getRawAxis(0));
-  }
-
-  /**
-   * Gets the rotation axis value for driving. unmodified.
-   * @return The rotation axis value.
-   */ 
-  public double driveRotAxisRaw() {
-    return -1*driverController.getRawAxis(4);
-  }
-  
-  /**
-   * Gets the Drive Rotation Axis with deadband and squared
-   * @return double Rotation Axis with deadband and squared
-   */
-  public double driveRotAxis() {
-    return -1*JoystickUtilities.joyDeadBndSqrd(driverController.getRawAxis(4),0.2);
-  }
-
-  // Driver Trigger Axes
-  public boolean robotCentricTrigger() {
-    return (driverController.getRawAxis(2) > 0.3);
-  }
-  public final Trigger robotCentric = new Trigger(this::robotCentricTrigger);
-
-  public boolean shooterOutTrigger() {
-    return (driverController.getRawAxis(3) > 0.3);
-  }
-  public final Trigger shooterShoot = new Trigger(this::shooterOutTrigger);
-  
-  // **** Co-Driver Controller ****
   private final XboxController coDriverController = new XboxController(1);
 
-  // Co-Driver Buttons
-  public final JoystickButton shooterRollerOutSlow = new JoystickButton(coDriverController, 1);
-  public final JoystickButton pickupNoteTransferToShooter = new JoystickButton(coDriverController, 2);
-  public final JoystickButton shooterAutoShoot = new JoystickButton(coDriverController, 4);
-  public final JoystickButton intakeOut = new JoystickButton(coDriverController, 5);
-  public final JoystickButton intakeIn = new JoystickButton(coDriverController, 6);
+  // Declare Robot Buttons
+  @Getter
+  private final JoystickButton intakeOut;
+  @Getter
+  private final JoystickButton intakeIn;
 
-  // Co-Driver POV
-  public final POVButton sliderOut = new POVButton(coDriverController, 0);
-  public final POVButton climberSupportExtend = new POVButton(coDriverController, 90);
-  public final POVButton sliderIn = new POVButton(coDriverController, 180);
-  public final POVButton climberSupportRetract = new POVButton(coDriverController, 270);
+  //Make Getters for
+  @Getter
+  private final JoystickButton turtleModeButton;
+  @Getter
+  private final JoystickButton turboModeButton;
+  @Getter
+  private final JoystickButton gyroResetButton;
+  @Getter
+  private final JoystickButton robotCentricButton;
 
-  // Co-Driver Axes
-  /**
-   * Gets the forward axis value for driving.
-   * 
-   * @return The value used for driving forward. unmodified. 
-   */
-  public double shooterArmAxisRaw() {
-    return -1*coDriverController.getRawAxis(5);
+  public HMIStation() {
+    // Initialize buttons
+    turtleModeButton = new JoystickButton(driverController, 5);
+    robotCentricButton = new JoystickButton(driverController, 2);
+    turboModeButton = new JoystickButton(driverController, 6);
+    gyroResetButton = new JoystickButton(driverController, 4);
+
+    intakeOut = new JoystickButton(coDriverController, 5);
+    intakeIn = new JoystickButton(coDriverController, 6);
+  }
+
+  @Override
+  protected double getDriveFwdAxis() {
+    return -driverController.getRawAxis(1);  // Invert Y-axis
+  }
+
+  @Override
+  protected double getDriveStrAxis() {
+    return -driverController.getRawAxis(0);  // Invert X-axis
+  }
+
+  @Override
+  protected double getDriveRotAxis() {
+    return -driverController.getRawAxis(4);  // Invert rotation axis
   }
 
   public double shooterArmAxis() {
-    return JoystickUtilities.joyDeadBndScaled(shooterArmAxisRaw(), .5, 1);
+    return JoystickUtilities.joyDeadBndScaled(-coDriverController.getRawAxis(5), .5, 1);
   }
 
-  /**
-   * Gets the rotation axis value for driving. unmodified.
-   *
-   * @return The rotation axis value.
-   */ 
-  public double intakeArmAxisRaw() {
+  public double intakeArmAxis() {
     return coDriverController.getRawAxis(1);
   }
-  
-  // Co Driver Trigger Axes
-   public boolean shooterSpeakerPosTrigger() {
-    return (coDriverController.getRawAxis(2) > 0.3);
-  }
-  public final Trigger shooterSpeakerPos = new Trigger(this::shooterSpeakerPosTrigger);
-
-  public boolean shooterAmpPosTrigger() {
-    return (coDriverController.getRawAxis(3) > 0.3);
-  }
-  public final Trigger shooterAmpPos = new Trigger(this::shooterAmpPosTrigger);
-  
-  // Aux Driver Controller
-  private final XboxController auxdriverController = new XboxController(2);
-
-  public final JoystickButton auxButton1 = new JoystickButton(auxdriverController, 1);
-  public final JoystickButton auxButton2 = new JoystickButton(auxdriverController, 2);
-  //public final JoystickButton auxButton3 = new JoystickButton(auxdriverController, 3);
-  //public final JoystickButton auxButton4 = new JoystickButton(auxdriverController, 4);
-  //public final JoystickButton auxButton5 = new JoystickButton(auxdriverController, 5);
-  //public final JoystickButton auxButton6 = new JoystickButton(auxdriverController, 6);
-  // Button Box
-
-  /**
-     * 
-     * @return XY mode
-     */
-    public double getDriveXYPerfMode(){
-        double xySpeed = DriveTrain.PerformanceModeDefault.DRIVE_TRAIN_MAX_SPD;
-        if(turtleModeButton.getAsBoolean()){
-            xySpeed = DriveTrain.PerformanceModeTurtle.DRIVE_TRAIN_MAX_SPD;
-        }else if(turboModeButton.getAsBoolean()){
-            xySpeed = DriveTrain.PerformanceModeTurbo.DRIVE_TRAIN_MAX_SPD;
-        }
-        return driveSpdPerfModeSwFilter.calculate(xySpeed);
-    }
-
-     /**
-     * 
-     * @return Rot mode
-     */
-    public double getDriveRotPerfMode(){
-        double rotSpeed = DriveTrain.PerformanceModeDefault.DRIVE_TRAIN_MAX_ROT_SPD;
-        if(turtleModeButton.getAsBoolean()){
-            rotSpeed = DriveTrain.PerformanceModeTurtle.DRIVE_TRAIN_MAX_ROT_SPD;
-        }else if(turboModeButton.getAsBoolean()){
-            rotSpeed = DriveTrain.PerformanceModeTurbo.DRIVE_TRAIN_MAX_ROT_SPD;
-        }
-        return driveRotPerfModeSwFilter.calculate(rotSpeed);
-    }
-  
-  // ---- Alliance Color
-  public void alliancePosition(){
-    DriverStation.getAlliance();
-  }
-
-
-
 
 }

--- a/src/main/java/frc/alotobots/library/HMIStationLib.java
+++ b/src/main/java/frc/alotobots/library/HMIStationLib.java
@@ -1,0 +1,86 @@
+package frc.alotobots.library;
+
+import edu.wpi.first.math.filter.SlewRateLimiter;
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import frc.alotobots.Constants;
+import frc.alotobots.library.driverstation.JoystickUtilities;
+
+public abstract class HMIStationLib {
+    final SlewRateLimiter driveFwdSpdFilter = new SlewRateLimiter(Constants.Robot.Calibrations.DriveTrain.DRIVE_TRAIN_MAX_ACCEL, Constants.Robot.Calibrations.DriveTrain.DRIVE_TRAIN_MAX_DECCEL,0);
+    final SlewRateLimiter driveStrSpdFilter = new SlewRateLimiter(Constants.Robot.Calibrations.DriveTrain.DRIVE_TRAIN_MAX_ACCEL, Constants.Robot.Calibrations.DriveTrain.DRIVE_TRAIN_MAX_DECCEL,0);
+
+  final SlewRateLimiter driveSpdPerfModeFilter = new SlewRateLimiter(Constants.Robot.Calibrations.DriveTrain.DRIVE_XY_SPD_PERF_MODE_SW_FILTER_RATE);
+  final SlewRateLimiter driveRotPerfModeFilter = new SlewRateLimiter(Constants.Robot.Calibrations.DriveTrain.DRIVE_ROT_SPD_PERF_MODE_SW_FILTER_RATE);
+
+  protected abstract JoystickButton getTurtleModeButton();
+  protected abstract JoystickButton getTurboModeButton();
+  protected abstract JoystickButton getGyroResetButton();
+  protected abstract JoystickButton getRobotCentricButton();
+
+  /**
+   * Gets the forward drive axis (not rate limited).
+   *
+   * @return The forward speed, typically between -1.0 and 1.0.
+   */
+  protected abstract double getDriveFwdAxis();
+
+  /**
+   * Gets the strafe drive axis (not rate limited).
+   *
+   * @return The strafe speed, typically between -1.0 and 1.0.
+   */
+  protected abstract double getDriveStrAxis();
+
+  /**
+   * Gets the rotation drive axis (not rate limited).
+   *
+   * @return The rotation speed, typically between -1.0 and 1.0.
+     */
+    protected abstract double getDriveRotAxis();
+
+
+    public double getDriveFwd() {
+      return -1 * driveFwdSpdFilter.calculate(getDriveFwdAxis());
+    }
+
+    public double getDriveStr() {
+      return -1 * driveStrSpdFilter.calculate(getDriveStrAxis());
+    }
+
+    public double getDriveRot() {
+      return -1 * JoystickUtilities.joyDeadBndSqrd(getDriveRotAxis(), 0.2);
+    }
+
+    /**
+     * Gets the current drive performance mode (speed multiplier).
+     *
+     * @return The current drive performance mode for XY movement.
+     */
+    public double getDriveXYPerfMode() {
+      double xySpeed = Constants.Robot.Calibrations.DriveTrain.PerformanceModeDefault.DRIVE_TRAIN_MAX_SPD;
+      if (getTurtleModeButton().getAsBoolean()) {
+        xySpeed = Constants.Robot.Calibrations.DriveTrain.PerformanceModeTurtle.DRIVE_TRAIN_MAX_SPD;
+      } else if (getTurboModeButton().getAsBoolean()) {
+        xySpeed = Constants.Robot.Calibrations.DriveTrain.PerformanceModeTurbo.DRIVE_TRAIN_MAX_SPD;
+      }
+      return driveSpdPerfModeFilter.calculate(xySpeed);
+    }
+
+    ;
+
+    /**
+     * Gets the current rotation performance mode (speed multiplier).
+     *
+     * @return The current drive performance mode for rotation.
+     */
+    public double getDriveRotPerfMode() {
+      double rotSpeed = Constants.Robot.Calibrations.DriveTrain.PerformanceModeDefault.DRIVE_TRAIN_MAX_ROT_SPD;
+      if (getTurtleModeButton().getAsBoolean()) {
+        rotSpeed = Constants.Robot.Calibrations.DriveTrain.PerformanceModeTurtle.DRIVE_TRAIN_MAX_ROT_SPD;
+      } else if (getTurboModeButton().getAsBoolean()) {
+        rotSpeed = Constants.Robot.Calibrations.DriveTrain.PerformanceModeTurbo.DRIVE_TRAIN_MAX_ROT_SPD;
+      }
+      return driveRotPerfModeFilter.calculate(rotSpeed);
+    }
+}


### PR DESCRIPTION
This will allow for more flexibility with the library and clean up the HMI station. By moving logic of the drive system in the HMI station to the abstract class we clean it up while maintaining the ability to change all button mappings year to year. One downside is that it uses abstraction which may be a complected topic for _"beginers"_ to understand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved control over robot movements with new getter methods for drive axes and performance modes.
	- Enhanced HMIStation with additional button functionalities for more precise control.

- **Refactor**
	- Switched to using getter methods in RobotContainer for cleaner and more maintainable code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->