### PR TITLE
Automatically format with spotless whenever gradle build or deploy is ran

### DIFF
--- a/.run/5152_Template [build].run.xml
+++ b/.run/5152_Template [build].run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false"
+    name="5152_Template [build]" type="GradleRunConfiguration"
+    factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="build" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/5152_Template [test].run.xml
+++ b/.run/5152_Template [test].run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false"
+    name="5152_Template [test]" type="GradleRunConfiguration"
+    factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Spotless format.run.xml
+++ b/.run/Spotless format.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Spotless format"
+    type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="spotlessApply" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/deploy.run.xml
+++ b/.run/deploy.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="deploy"
+    type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="deploy" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,10 @@ tasks.withType(JavaCompile) {
   options.compilerArgs.add '-XDstringConcat=inline'
 }
 
+// Make deploy and build tasks depend on spotlessApply
+deploy.dependsOn spotlessApply
+build.dependsOn spotlessApply
+
 spotless {
   java {
     target fileTree('.') {

--- a/build.gradle
+++ b/build.gradle
@@ -107,8 +107,12 @@ tasks.withType(JavaCompile) {
 }
 
 // Make deploy and build tasks depend on spotlessApply
-deploy.dependsOn spotlessApply
-build.dependsOn spotlessApply
+tasks.named('deploy') {
+  dependsOn spotlessApply
+}
+tasks.named('build') {
+  dependsOn spotlessApply
+}
 
 spotless {
   java {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced multiple Gradle run configurations: 
		- "5152_Template [build]" for building the project.
		- "5152_Template [test]" for executing tests.
		- "Spotless format" for applying code formatting.
		- "deploy" for deployment tasks.
	- Integrated Spotless plugin for code style enforcement.

- **Bug Fixes**
	- Ensured code formatting is applied before executing build and deploy tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->