### PR TITLE
fix apriltags not showing under subsystem docs

### DIFF
--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
           - Swerve: library/subsystems/swerve.md
           - Vision:
               - Object Detection: library/subsystems/vision/objectdetection.md
+              - AprilTag: library/subsystems/vision/apriltag.md
   - Quickstart: quickstart.md
   - API Documentation: javadoc/index.html # Point directly to index.html
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new entry titled "AprilTag" to the navigation under the "Vision" section in the documentation.
- **Documentation**
	- Enhanced documentation with information related to AprilTag functionality within the vision subsystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->